### PR TITLE
Test CDN with single cache

### DIFF
--- a/_locals.tf
+++ b/_locals.tf
@@ -1,4 +1,8 @@
 locals {
+  cdn_hostnames_aliases = "${split(",", var.environment == "production" ? join(",",var.hostnames_prod) : join(",", var.hostnames_staging))}"
+}
+
+locals {
   common_tags = {
     Product          = "${var.product}"
     Project          = "${var.project}"
@@ -7,6 +11,16 @@ locals {
     Environment      = "${var.environment}"
     LastUpdate       = "${timestamp()}"
     GitHash          = "${var.git-hash}"
+  }
+}
+
+locals {
+  common_tags_cdn = {
+    Product          = "${var.product}"
+    Project          = "${var.project}"
+    EmergencyContact = "${var.emergency-contact}"
+    Owner            = "${var.owner}"
+    Environment      = "${var.environment}"
   }
 }
 

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -2,3 +2,9 @@ output "domain-load-balancer" {
   description = "The public domain of the load-balancer"
   value       = "${aws_lb.alb.dns_name}"
 }
+
+output "cloudfront-id" {
+  description = "The AWS ID of the cloudfront distribution"
+  value       = "${join(" ", aws_cloudfront_distribution.cdn.*.id)}"
+}
+

--- a/_variables.tf
+++ b/_variables.tf
@@ -266,14 +266,14 @@ variable "cfd_default_max_ttl" {
   default     = 86400
 }
 
-variable "cfd_ordered_regular_ttl" {
-  description = "The (regular) TTL of the ordered cache behaviour(es)"
-  type        = "string"
-  default     = 3600
+variable "hostnames_staging" {
+  description = "The hostnames for the staging environment"
+  type        = "list"
+  default     = []
 }
 
-variable "cfd_ordered_max_ttl" {
-  description = "The maximum TTL of the ordered cache behaviour(es)"
-  type        = "string"
-  default     = 86400
+variable "hostnames_prod" {
+  description = "The hostnames for the production environment"
+  type        = "list"
+  default     = []
 }


### PR DESCRIPTION
This PR alters the CDN to:
- have a single cache, with a high TTL;
- allow multiple CDN aliases, for staging and production environments;