### PR TITLE
Update caching strategy to fix live issue

### DIFF
--- a/_cdn.tf
+++ b/_cdn.tf
@@ -53,8 +53,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     forwarded_values = {
       query_string = true
-      query_string_cache_keys = ["ecdesign"]
-      headers      = ["Host"]
+      headers      = ["Host", "X-Economist-Host"]
 
       cookies = {
         forward = "whitelist"


### PR DESCRIPTION
* "stage.economist.com" and "beta.economist.com" should each cache as separate pages.

This would normally work as-is, as the Host header was already specified as an exclusion, but on The Economist Gateway the `Host` header is re-written as `X-Economist-Header` (and the value for `Host` is always "beta.economist.com" as that's how the proxying works.

Both stage and prod Economist Gateways point to production CDN, so they are currently sharing the same cache entry - although any user who has previously visited will bust through the cache (as they have cookies uniquely identifying them) and so they will get a server side rendered page instead of the CDN version, so the impact has thankfully been minimised in practice.

* We have also removed the `ecdesign` query string exception. This query string is not used by our app (only by The Economist Gateway which sits in front of it in production) and actually it's causing caching of requests based query strings by having a whitelist at all.

Note: We have already verified this is the behaviour we want and that it works in AWS on production and staging, this is just committing those changes to our Terraform config so they are persisted.