### PR TITLE
Add configurable deregistration delay on ALB target groups

### DIFF
--- a/_alb.tf
+++ b/_alb.tf
@@ -12,10 +12,11 @@ resource "aws_lb" "alb" {
 }
 
 resource "aws_lb_target_group" "lb_target" {
-  name_prefix = "${var.target-group-name}"
-  port        = 80
-  protocol    = "HTTP"
-  vpc_id      = "${aws_vpc.vpc.id}"
+  name_prefix          = "${var.target-group-name}"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = "${aws_vpc.vpc.id}"
+  deregistration_delay = "${var.target-group-deregistration-delay}"
 
   health_check = {
     interval            = "${var.health_check_interval}"

--- a/_variables.tf
+++ b/_variables.tf
@@ -122,6 +122,12 @@ variable "target-group-name" {
   default     = "lb-tg"
 }
 
+variable "target-group-deregistration-delay" {
+  description = "The amount of time to wait before changing the state of a deregistering target from draining to unused"
+  type        = "string"
+  default     = 500
+}
+
 variable "launch-config-name" {
   description = "The name of the launch configuration"
   type        = "string"


### PR DESCRIPTION
The deregistration delay is the amount of time the ALB waits to change
the state of a deregistering instance from "draining" to "unused". The
default is 300 seconds which is too long for non-prod environments.