### PR TITLE
Add `geo_region` cookie to whitelisted cookie names

### DIFF
--- a/_cdn.tf
+++ b/_cdn.tf
@@ -60,7 +60,8 @@ resource "aws_cloudfront_distribution" "cdn" {
         whitelisted_names = [
           "economist_amp_consent",
           "economist_piano_id",
-          "economist_has_visited_app_before"
+          "economist_has_visited_app_before",
+          "geo_region"
         ]
       }
     }


### PR DESCRIPTION
This cookie is used by the node app to determine content for user
based on their region.