### PR TITLE
Whitelisted incap-geo header

### DIFF
--- a/_cdn.tf
+++ b/_cdn.tf
@@ -53,7 +53,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     forwarded_values = {
       query_string = true
-      headers      = ["Host", "X-Economist-Host"]
+      headers      = ["Host", "X-Economist-Host", "incap-geo"]
 
       cookies = {
         forward = "whitelist"


### PR DESCRIPTION
Added `incap-geo` header to  the whitelist.

https://jira.economist.com/browse/WE-1163
