### PR TITLE
WE-1196 - Add a internal dns entry

### DIFF
--- a/_route53.tf
+++ b/_route53.tf
@@ -29,21 +29,38 @@ data "aws_acm_certificate" "example" {
 resource "aws_route53_record" "www" {
   count = "${var.domain-name != "" ? 1 : 0}"
 
-  depends_on = ["aws_lb.alb", "aws_cloudfront_distribution.cdn"]  
+  depends_on = ["aws_lb.alb", "aws_cloudfront_distribution.cdn"]
 
   zone_id = "${data.aws_route53_zone.primary.zone_id}"
   name    = "${var.domain-name}"
   type    = "A"
 
   alias = {
-    // we use concat because 'count' makes the response of the resource a list. 
+    // we use concat because 'count' makes the response of the resource a list.
     // link to similar issue: https://stackoverflow.com/questions/45654774/terraform-conditional-resource
-    name                   = "${var.use_cloudfront == "true" ? element(concat(aws_cloudfront_distribution.cdn.*.domain_name, list("")), 0) : aws_lb.alb.dns_name}"    
+    name                   = "${var.use_cloudfront == "true" ? element(concat(aws_cloudfront_distribution.cdn.*.domain_name, list("")), 0) : aws_lb.alb.dns_name}"
     zone_id                = "${var.use_cloudfront == "true" ? element(concat(aws_cloudfront_distribution.cdn.*.hosted_zone_id, list("")), 0) : aws_lb.alb.zone_id}"
     evaluate_target_health = true
   }
 }
 
+resource "aws_route53_record" "internal-dns" {
+  zone_id = "${data.aws_route53_zone.primary.zone_id}"
+  name    = "${var.internal-domain-name}"
+  type    = "A"
+
+  weighted_routing_policy {
+    weight = 100
+  }
+
+  set_identifier = "old_env"
+
+  alias = {
+    name = "${aws_lb.alb.dns_name}"
+    zone_id = "${aws_lb.alb.zone_id}"
+    evaluate_target_health = false
+  }
+}
 
 # configure sub-domain
 # resource "aws_route53_record" "sub" {

--- a/_route53.tf
+++ b/_route53.tf
@@ -45,6 +45,7 @@ resource "aws_route53_record" "www" {
 }
 
 resource "aws_route53_record" "internal-dns" {
+  count = "${var.internal-domain-name == "" ? 0 : 1}"
   zone_id = "${data.aws_route53_zone.primary.zone_id}"
   name    = "${var.internal-domain-name}"
   type    = "A"

--- a/_route53.tf
+++ b/_route53.tf
@@ -24,7 +24,6 @@ data "aws_acm_certificate" "example" {
   domain   = "${var.root-domain}"
 }
 
-
 // Route53 for Cloudfront
 resource "aws_route53_record" "www" {
   count = "${var.domain-name != "" ? 1 : 0}"
@@ -49,6 +48,8 @@ resource "aws_route53_record" "internal-dns" {
   zone_id = "${data.aws_route53_zone.primary.zone_id}"
   name    = "${var.internal-domain-name}"
   type    = "A"
+
+  depends_on = ["aws_lb.alb"]
 
   weighted_routing_policy {
     weight = 100

--- a/_route53.tf
+++ b/_route53.tf
@@ -51,7 +51,7 @@ resource "aws_route53_record" "internal-dns" {
 
   depends_on = ["aws_lb.alb"]
 
-  weighted_routing_policy {
+  weighted_routing_policy = {
     weight = 100
   }
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -167,6 +167,7 @@ variable "sub-domain-name" {
 variable "internal-domain-name" {
   description = "Internal DNS name which refers to the ALB"
   type        = "string"
+  default     = ""
 }
 
 variable "ssh-allowed-ips" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -164,6 +164,11 @@ variable "sub-domain-name" {
   default     = ""
 }
 
+variable "internal-domain-name" {
+  description = "Internal DNS name which refers to the ALB"
+  type        = "string"
+}
+
 variable "ssh-allowed-ips" {
   description = "The list of IPs that are allowed to SSH into the instances"
   type        = "list"


### PR DESCRIPTION
This will be used to divide the traffic from cloudfront to multiple
environments by using weighted DNS on the internal DNS entry