### PR TITLE
WE-1196 - CDN Source

### DIFF
--- a/_cdn.tf
+++ b/_cdn.tf
@@ -11,12 +11,14 @@ resource "aws_s3_bucket" "s3_bucket_logs" {
 resource "aws_cloudfront_distribution" "cdn" {
   count = "${var.use_cloudfront != "false" ? 1 : 0}"
 
+  depends_on = ["aws_route53_record.internal-dns"]
+
   aliases = ["${var.domain-name}", "${local.cdn_hostnames_aliases}"]
   enabled = true
 
   origin = {
-    domain_name = "${aws_lb.alb.dns_name}"
-    origin_id   = "${aws_lb.alb.id}"
+    domain_name = "${aws_route53_record.internal-dns.name}"
+    origin_id   = "internal-dns"
 
     custom_origin_config = {
       http_port              = 80

--- a/_route53.tf
+++ b/_route53.tf
@@ -44,7 +44,6 @@ resource "aws_route53_record" "www" {
 }
 
 resource "aws_route53_record" "internal-dns" {
-  count = "${var.internal-domain-name == "" ? 0 : 1}"
   zone_id = "${data.aws_route53_zone.primary.zone_id}"
   name    = "${var.internal-domain-name}"
   type    = "A"

--- a/_variables.tf
+++ b/_variables.tf
@@ -167,7 +167,6 @@ variable "sub-domain-name" {
 variable "internal-domain-name" {
   description = "Internal DNS name which refers to the ALB"
   type        = "string"
-  default     = ""
 }
 
 variable "ssh-allowed-ips" {


### PR DESCRIPTION
Move the CloudFront origin to the internal DNS name. This needs to be applied in two stages to avoid the race condition of DNS propagation. 