### PR TITLE
we-1200 - Allow internal domain weight to be configured

### DIFF
--- a/_route53.tf
+++ b/_route53.tf
@@ -53,7 +53,7 @@ resource "aws_route53_record" "internal-dns" {
   depends_on = ["aws_lb.alb"]
 
   weighted_routing_policy = {
-    weight = 100
+    weight = ${var.internal-domain-weight}
   }
 
   set_identifier = "old_env"

--- a/_variables.tf
+++ b/_variables.tf
@@ -169,6 +169,12 @@ variable "internal-domain-name" {
   type        = "string"
 }
 
+variable "internal-domain-weight" {
+  description = "Internal DNS weight which refers to the ALB"
+  type        = "number"
+  default     = 100
+}
+
 variable "ssh-allowed-ips" {
   description = "The list of IPs that are allowed to SSH into the instances"
   type        = "list"


### PR DESCRIPTION
To be able to decrease traffic to the EC2 environment the DNS weight needs to be configured externally.