### PR TITLE
WE-1207: Add login_callback cookie to whitelist

### DIFF
--- a/_cdn.tf
+++ b/_cdn.tf
@@ -64,6 +64,7 @@ resource "aws_cloudfront_distribution" "cdn" {
           "economist_piano_id",
           "economist_has_visited_app_before",
           "ec_community",
+          "login_callback",
           "geo_region"
         ]
       }


### PR DESCRIPTION
This will allow the Next app to pick up on the cookie set by the login callback, allowing the app to fire an event right after a successful login.